### PR TITLE
Retrieve attributes from the block before rendering

### DIFF
--- a/src/DefinitionListItemDefinitionRenderer.php
+++ b/src/DefinitionListItemDefinitionRenderer.php
@@ -14,6 +14,8 @@ class DefinitionListItemDefinitionRenderer implements BlockRendererInterface
             throw new \InvalidArgumentException('Incompatible block type: ' . \get_class($block));
         }
 
-        return new HtmlElement('dd', [], $htmlRenderer->renderBlocks($block->children(), $inTightList));
+        $attrs = $block->getData('attributes', []);
+
+        return new HtmlElement('dd', $attrs, $htmlRenderer->renderBlocks($block->children(), $inTightList));
     }
 }

--- a/src/DefinitionListItemTermRenderer.php
+++ b/src/DefinitionListItemTermRenderer.php
@@ -14,6 +14,8 @@ class DefinitionListItemTermRenderer implements BlockRendererInterface
             throw new \InvalidArgumentException('Incompatible block type: ' . \get_class($block));
         }
 
-        return new HtmlElement('dt', [], $htmlRenderer->renderInlines($block->children()));
+        $attrs = $block->getData('attributes', []);
+
+        return new HtmlElement('dt', $attrs, $htmlRenderer->renderInlines($block->children()));
     }
 }

--- a/src/DefinitionListRenderer.php
+++ b/src/DefinitionListRenderer.php
@@ -14,6 +14,8 @@ class DefinitionListRenderer implements BlockRendererInterface
             throw new \InvalidArgumentException('Incompatible block type: ' . \get_class($block));
         }
 
-        return new HtmlElement('dl', [], $htmlRenderer->renderBlocks($block->children(), $block->isTight()));
+        $attrs = $block->getData('attributes', []);
+
+        return new HtmlElement('dl', $attrs, $htmlRenderer->renderBlocks($block->children(), $block->isTight()));
     }
 }

--- a/test/AttributeRenderingTest.php
+++ b/test/AttributeRenderingTest.php
@@ -1,0 +1,49 @@
+<?php
+namespace Moxio\CommonMark\Extension\DefinitionList\Test;
+
+use League\CommonMark\Environment;
+use League\CommonMark\HtmlRenderer;
+use Moxio\CommonMark\Extension\DefinitionList\DefinitionList;
+use Moxio\CommonMark\Extension\DefinitionList\DefinitionListExtension;
+use Moxio\CommonMark\Extension\DefinitionList\DefinitionListItemDefinition;
+use Moxio\CommonMark\Extension\DefinitionList\DefinitionListItemTerm;
+use PHPUnit\Framework\TestCase;
+
+class AttributeRenderingTest extends TestCase
+{
+    private HtmlRenderer $renderer;
+
+    protected function setUp(): void
+    {
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new DefinitionListExtension());
+        $this->renderer = new HtmlRenderer($environment);
+    }
+
+    public function testCorrectlyRendersAttributesOfDefinitionList(): void
+    {
+        $block = new DefinitionList();
+        $block->data['attributes'] = ['id' => 'foo'];
+        $actualOutput = $this->renderer->renderBlock($block);
+
+        $this->assertXmlStringEqualsXmlString("<html><dl id=\"foo\"></dl></html>", "<html>$actualOutput</html>");
+    }
+
+    public function testCorrectlyRendersAttributesOfDefinitionListItemDefinition(): void
+    {
+        $block = new DefinitionListItemDefinition();
+        $block->data['attributes'] = ['id' => 'foo'];
+        $actualOutput = $this->renderer->renderBlock($block);
+
+        $this->assertXmlStringEqualsXmlString("<html><dd id=\"foo\"></dd></html>", "<html>$actualOutput</html>");
+    }
+
+    public function testCorrectlyRendersAttributesOfDefinitionListItemTerm(): void
+    {
+        $block = new DefinitionListItemTerm([]);
+        $block->data['attributes'] = ['id' => 'foo'];
+        $actualOutput = $this->renderer->renderBlock($block);
+
+        $this->assertXmlStringEqualsXmlString("<html><dt id=\"foo\"></dt></html>", "<html>$actualOutput</html>");
+    }
+}


### PR DESCRIPTION
Adds block attributes before rendering them. 

Currently, it's not possible to add classes using an Event Listener.